### PR TITLE
Change books table

### DIFF
--- a/db/migrate/20200602142008_change_books.rb
+++ b/db/migrate/20200602142008_change_books.rb
@@ -4,5 +4,6 @@ class ChangeBooks < ActiveRecord::Migration[6.0]
       t.remove :series
       t.text :description
       t.rename :publishing_year, :published_date
+    end
   end
 end

--- a/db/migrate/20200602142008_change_books.rb
+++ b/db/migrate/20200602142008_change_books.rb
@@ -1,0 +1,8 @@
+class ChangeBooks < ActiveRecord::Migration[6.0]
+  def change
+    change_table :books do |t|
+      t.remove :series
+      t.text :description
+      t.rename :publishing_year, :published_date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_30_142334) do
+ActiveRecord::Schema.define(version: 2020_06_02_142008) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -18,14 +18,14 @@ ActiveRecord::Schema.define(version: 2020_05_30_142334) do
   create_table "books", force: :cascade do |t|
     t.string "title"
     t.string "author"
-    t.integer "publishing_year"
-    t.string "series"
+    t.integer "published_date"
     t.integer "rating"
     t.string "publisher"
     t.bigint "lender_id"
     t.string "category"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.text "description"
     t.index ["lender_id"], name: "index_books_on_lender_id"
   end
 


### PR DESCRIPTION
J'ai créé et joué une migration pour :

- supprimer le field `series` de la table `books`
- ajouter le field `description` à la table `books`
- renommer le field `publishing_year` en `published_date` dans la table `books` (après vérification, c'est plus correct)

Si vous êtes ok, vous pouvez merger & :

- git status (il doit être clean d'après le cours :) )
- git checkout master
- git pull origin master
- rails db:migrate